### PR TITLE
Ability to list index types and ability to generate ES bulk format dumps

### DIFF
--- a/esprit/raw.py
+++ b/esprit/raw.py
@@ -344,17 +344,28 @@ def store(connection, type, record, id=None, params=None):
     return resp
 
 
-def to_bulk(records, idkey="id"):
+def to_bulk(records, idkey="id", index='', type_=''):
     data = ''
     for r in records:
-        data += json.dumps({'index': {'_id': r[idkey]}}) + '\n'
-        data += json.dumps(r) + '\n'
+        to_bulk_single_rec(r, idkey=idkey, index=index, type_=type_)
     return data
 
 
-def bulk(connection, type, records, idkey='id'):
+def to_bulk_single_rec(record, idkey="id", index='', type_=''):
+    data = ''
+    datadict = {'index': {'_id': record[idkey]}}
+    if index:
+        datadict['index']['_index'] = index
+    if type_:
+        datadict['index']['_type'] = type_
+    data += json.dumps(datadict) + '\n'
+    data += json.dumps(record) + '\n'
+    return data
+
+
+def bulk(connection, records, idkey='id', type_=''):
     data = to_bulk(records, idkey=idkey)
-    url = elasticsearch_url(connection, type, endpoint="_bulk")
+    url = elasticsearch_url(connection, type_, endpoint="_bulk")
     resp = _do_post(url, connection, data=data)
     return resp
 

--- a/esprit/raw.py
+++ b/esprit/raw.py
@@ -437,10 +437,9 @@ def post_alias(connection, alias_actions):
 ##############################################################
 # List types
 
-def list_types(connection, index_name_override=''):
+
+def list_types(connection):
     url = elasticsearch_url(connection, "_mapping")
-    resp = _do_get(url, connection)
-    index = connection.index
-    if index_name_override:  # for an aliased index, connection.index may be different than what the mappings return
-        index = index_name_override
-    return resp.json()[index]['mappings'].keys()
+    resp = _do_get(url, connection).json()
+    index = resp.keys()[0]
+    return resp[index]['mappings'].keys()

--- a/esprit/raw.py
+++ b/esprit/raw.py
@@ -422,3 +422,14 @@ def post_alias(connection, alias_actions):
     url = elasticsearch_url(connection, endpoint="_aliases", omit_index=True)
     resp = _do_post(url, connection, json.dumps(alias_actions))
     return resp
+
+##############################################################
+# List types
+
+def list_types(connection, index_name_override=''):
+    url = elasticsearch_url(connection, "_mapping")
+    resp = _do_get(url, connection)
+    index = connection.index
+    if index_name_override:  # for an aliased index, connection.index may be different than what the mappings return
+        index = index_name_override
+    return resp.json()[index]['mappings'].keys()

--- a/esprit/tasks.py
+++ b/esprit/tasks.py
@@ -93,13 +93,16 @@ def iterate(conn, type, q, page_size=1000, limit=None, method="POST"):
         q["from"] += page_size
 
 
-def dump(conn, type, q=None, page_size=1000, limit=None, method="POST", out=None, transform=None):
+def dump(conn, type, q=None, page_size=1000, limit=None, method="POST", out=None, transform=None, es_bulk_format=True, idkey='id'):
     q = q if q is not None else {"query": {"match_all": {}}}
     out = out if out is not None else sys.stdout
     for record in iterate(conn, type, q, page_size=page_size, limit=limit, method=method):
         if transform is not None:
             record = transform(record)
-        out.write(json.dumps(record) + "\n")
+        if es_bulk_format:
+            out.write(raw.to_bulk_single_rec(record, idkey=idkey, index=conn.index, type_=type))
+        else:
+            out.write(json.dumps(record) + "\n")
 
 
 def create_alias(conn, alias):

--- a/esprit/tasks.py
+++ b/esprit/tasks.py
@@ -14,11 +14,11 @@ def copy(source_conn, source_type, target_conn, target_type, limit=None, batch_s
         batch.append(r)
         if len(batch) >= batch_size:
             print "writing batch of", len(batch)
-            raw.bulk(target_conn, target_type, batch)
+            raw.bulk(target_conn, batch, type_=target_type)
             batch = []
     if len(batch) > 0:
         print "writing batch of", len(batch)
-        raw.bulk(target_conn, target_type, batch)
+        raw.bulk(target_conn, batch, type_=target_type)
 
 
 def scroll(conn, type, q=None, page_size=1000, limit=None, keepalive="1m"):


### PR DESCRIPTION
Adds a new raw ability and modifies the dump task as mentioned in the title.

Breaking change on `def bulk` to make `type` arg optional for easier restores. The restore process doesn't have to care about the ES type - it's generally harder to encode that info in restore unless you're only ever restoring 1 type). Instead, just use the mechanism provided by ES and encode the info in the bulk record metadata (the 1st of the 2 lines in the format).